### PR TITLE
Update ActivityLogger.php

### DIFF
--- a/src/app/Http/Traits/ActivityLogger.php
+++ b/src/app/Http/Traits/ActivityLogger.php
@@ -61,7 +61,7 @@ trait ActivityLogger
             'userId'        => $userId,
             'route'         => \Request::fullUrl(),
             'ipAddress'     => \Request::ip(),
-            'userAgent'     => \Request::userAgent(),
+            'userAgent'     => \Request::header('user-agent'),
             'locale'        => \Request::header('accept-language'),
             'referer'       => \Request::header('referer'),
             'methodType'    => \Request::method(),


### PR DESCRIPTION
\Request::userAgent() changed to \Request::header('user-agent') because its not yet available in Laravel 5.3