### PR TITLE
Fix for #34 - The referer format is invalid

### DIFF
--- a/src/app/Models/Activity.php
+++ b/src/app/Models/Activity.php
@@ -70,11 +70,11 @@ class Activity extends Model
     protected $casts = [
         'description'   => 'string',
         'user'          => 'integer',
-        'route'         => 'url',
+        'route'         => 'string',
         'ipAddress'     => 'ipAddress',
         'userAgent'     => 'string',
         'locale'        => 'string',
-        'referer'       => 'url',
+        'referer'       => 'string',
         'methodType'    => 'string',
     ];
 
@@ -133,7 +133,7 @@ class Activity extends Model
             'ipAddress'     => 'nullable|ip',
             'userAgent'     => 'nullable|string',
             'locale'        => 'nullable|string',
-            'referer'       => 'nullable|url',
+            'referer'       => 'nullable|string',
             'methodType'    => 'nullable|string',
         ],
         $merge);


### PR DESCRIPTION
All cast type with url has been replaced to string. 
The validation rule for referer has been changed from nullable|url to nullable|string.
Fix for issue #34 