### PR TITLE
Add activity created_at timestamp as title for the 'time' cell.

### DIFF
--- a/src/resources/views/logger/partials/activity-table.blade.php
+++ b/src/resources/views/logger/partials/activity-table.blade.php
@@ -77,7 +77,7 @@ if (Request::is('activity/cleared')) {
                             @endif
                         </small>
                     </td>
-                    <td>
+                    <td title="{{ $activity->created_at }}">
                         {{ $activity->timePassed }}
                     </td>
                     <td>


### PR DESCRIPTION
Adding the timestamp as title to the cell showing time ago for the event, so that by hovering over it, we get the full timestamp.

A minor change I found useful on my project when hunting for activity log entries corresponding to an event in the log files. With this I avoid clicking into a lot of activity items to check the timestamps to find those that match to the minute and/or second.