### PR TITLE
Give default value in config helper for middleware except array.

### DIFF
--- a/src/app/Http/Middleware/LogActivity.php
+++ b/src/app/Http/Middleware/LogActivity.php
@@ -36,7 +36,7 @@ class LogActivity
      */
     protected function shouldLog($request)
     {
-        foreach (config('LaravelLogger.loggerMiddlewareExcept') as $except) {
+        foreach (config('LaravelLogger.loggerMiddlewareExcept', []) as $except) {
             if ($except !== '/') {
                 $except = trim($except, '/');
             }


### PR DESCRIPTION
Rationale for this is the case where the config file has been published, but does not (yet) contain the string to array logic.

Unlikely to be a problem for new installs, but keeps cropping up when working with different versions of Laravel-Logger on different branches. (Could possibly also be an issue during prod release / rollback cycle, depending on the setup.)