### PR TITLE
Add DB_CONNECTION as fallback for LARAVEL_LOGGER_DATABASE_CONNECTION

### DIFF
--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -8,7 +8,7 @@ return [
     |--------------------------------------------------------------------------
     */
 
-    'loggerDatabaseConnection'  => env('LARAVEL_LOGGER_DATABASE_CONNECTION', 'mysql'),
+    'loggerDatabaseConnection'  => env('LARAVEL_LOGGER_DATABASE_CONNECTION', env('DB_CONNECTION', 'mysql')),
     'loggerDatabaseTable'       => env('LARAVEL_LOGGER_DATABASE_TABLE', 'laravel_logger_activity'),
 
     /*


### PR DESCRIPTION
When using a database different from MySQL, laravel-logger fails to migrate because of the default `mysql` value.

Now, when `LARAVEL_LOGGER_DATABASE_CONNECTION` has not been added to `.env`, `DB_CONNECTION` is used instead.

If none of them exist, `'mysql'` is used as default value.