### PR TITLE
Update LaravelLoggerServiceProvider.php

### DIFF
--- a/src/LaravelLoggerServiceProvider.php
+++ b/src/LaravelLoggerServiceProvider.php
@@ -116,7 +116,7 @@ class LaravelLoggerServiceProvider extends ServiceProvider
      */
     private function publishFiles()
     {
-        $publishTag = 'laravellogger';
+        $publishTag = 'LaravelLogger';
 
         $this->publishes([
             __DIR__.'/config/laravel-logger.php' => base_path('config/laravel-logger.php'),


### PR DESCRIPTION
Если `$publishTag = 'laravellogger'`, тогда после команды
`artisan vendor:publish --tag=laravellogger`
не подцепится */views*, т.к. `$namespace='LaravelLogger'`.

```
public function register()
{
    /*...*/
    $this->loadViewsFrom(__DIR__.'/resources/views/', 'LaravelLogger');
    /*...*/
}
```

Поэтому надо было изменить `$publishTag` или `$namespace`.