### PR TITLE
Typo in namespace for web.php in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ If you are on an existing install, you will also need update your `laravel-logge
 You can then add the routes directly to your application's `routes/web.php` file, and customise as required.
 
 ```php
-Route::group(['prefix' => 'activity', 'namespace' => 'jeremykenedy\LaravelLogger\App\Http\Controllers', 'middleware' => ['web', 'auth', 'activity']], function () {
+Route::group(['prefix' => 'activity', 'namespace' => '\jeremykenedy\LaravelLogger\App\Http\Controllers', 'middleware' => ['web', 'auth', 'activity']], function () {
 
     // Dashboards
     Route::get('/', 'LaravelLoggerController@showAccessLog')->name('activity');


### PR DESCRIPTION
Without \ before *jeremykenedy* in a namespace, it will give an error.