### PR TITLE
Fixes issue on Validation check And Updates Facades usage

### DIFF
--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -3,10 +3,11 @@
 namespace jeremykenedy\LaravelLogger\App\Http\Traits;
 
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Validator;
 use Jaybizzle\LaravelCrawlerDetect\Facades\LaravelCrawlerDetect as Crawler;
 use jeremykenedy\LaravelLogger\App\Models\Activity;
-use Validator;
 
 trait ActivityLogger
 {
@@ -22,7 +23,7 @@ trait ActivityLogger
         $userType = trans('LaravelLogger::laravel-logger.userTypes.guest');
         $userId = null;
 
-        if (\Auth::check()) {
+        if (Auth::check()) {
             $userType = trans('LaravelLogger::laravel-logger.userTypes.registered');
             $userIdField = config('LaravelLogger.defaultUserIDField');
             $userId = Request::user()->{$userIdField};
@@ -72,7 +73,7 @@ trait ActivityLogger
         ];
 
         // Validation Instance
-        $validator = Validator::make($data, Activity::Rules([]));
+        $validator = Validator::make($data, Activity::rules([]));
         if ($validator->fails()) {
             $errors = self::prepareErrorMessage($validator->errors(), $data);
             if (config('LaravelLogger.logDBActivityLogFailuresToFile')) {

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -2,8 +2,8 @@
 
 namespace jeremykenedy\LaravelLogger\App\Http\Traits;
 
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Validator;
 use Jaybizzle\LaravelCrawlerDetect\Facades\LaravelCrawlerDetect as Crawler;
@@ -73,7 +73,7 @@ trait ActivityLogger
         ];
 
         // Validation Instance
-        $validator = Validator::make($data, Activity::rules([]));
+        $validator = Validator::make($data, Activity::rules());
         if ($validator->fails()) {
             $errors = self::prepareErrorMessage($validator->errors(), $data);
             if (config('LaravelLogger.logDBActivityLogFailuresToFile')) {

--- a/src/App/Models/Activity.php
+++ b/src/App/Models/Activity.php
@@ -130,12 +130,13 @@ class Activity extends Model
         } else {
             $route_url_check = 'url';
         }
+
         return array_merge(
             [
                 'description'   => 'required|string',
                 'userType'      => 'required|string',
                 'userId'        => 'nullable|integer',
-                'route'         => 'nullable|' . $route_url_check,
+                'route'         => 'nullable|'.$route_url_check,
                 'ipAddress'     => 'nullable|ip',
                 'userAgent'     => 'nullable|string',
                 'locale'        => 'nullable|string',

--- a/src/App/Models/Activity.php
+++ b/src/App/Models/Activity.php
@@ -125,12 +125,17 @@ class Activity extends Model
      */
     public static function rules($merge = [])
     {
+        if (\Illuminate\Foundation\Application::VERSION < 5.8) {
+            $route_url_check = 'active_url';
+        } else {
+            $route_url_check = 'url';
+        }
         return array_merge(
             [
                 'description'   => 'required|string',
                 'userType'      => 'required|string',
                 'userId'        => 'nullable|integer',
-                'route'         => 'nullable|url',
+                'route'         => 'nullable|' . $route_url_check,
                 'ipAddress'     => 'nullable|ip',
                 'userAgent'     => 'nullable|string',
                 'locale'        => 'nullable|string',

--- a/src/LaravelLoggerServiceProvider.php
+++ b/src/LaravelLoggerServiceProvider.php
@@ -3,6 +3,7 @@
 namespace jeremykenedy\LaravelLogger;
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use jeremykenedy\LaravelLogger\App\Http\Middleware\LogActivity;
 
@@ -109,7 +110,7 @@ class LaravelLoggerServiceProvider extends ServiceProvider
         $listeners = $this->getListeners();
         foreach ($listeners as $listenerKey => $listenerValues) {
             foreach ($listenerValues as $listenerValue) {
-                \Event::listen(
+                Event::listen(
                     $listenerKey,
                     $listenerValue
                 );


### PR DESCRIPTION
The Validation check can be validated here - https://github.com/laravel/framework/blob/5.8/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L1618

The main issue is that if a domain has an underscore e.g. **https://foo_bar.com** the validation returns false, but on 5.8 they added that extra validation to the regex.

The facades usage, is mostly something that should be done, because we don't know if the developer of the project that uses the package has the aliases enabled or not, so we use the Facades instead of the aliases.

And updates a (misspelled?) function name usage from **R**ules to **r**ules