### PR TITLE
fix invalid cast type from ipAddress to string - fixes #97

### DIFF
--- a/src/App/Models/Activity.php
+++ b/src/App/Models/Activity.php
@@ -71,7 +71,7 @@ class Activity extends Model
         'description'   => 'string',
         'user'          => 'integer',
         'route'         => 'string',
-        'ipAddress'     => 'ipAddress',
+        'ipAddress'     => 'string',
         'userAgent'     => 'string',
         'locale'        => 'string',
         'referer'       => 'string',


### PR DESCRIPTION
Jeremy - Here is a quick PR to resolve the issue with the previously unchecked but invalid ipAddress casting in the Activity model. Laravel 8 now throws an exception. Peace - Anthony