### PR TITLE
Add chromeos

### DIFF
--- a/src/App/Http/Controllers/LaravelLoggerController.php
+++ b/src/App/Http/Controllers/LaravelLoggerController.php
@@ -51,7 +51,7 @@ class LaravelLoggerController extends BaseController
         $collectionItems->map(function ($collectionItem) {
             $eventTime = Carbon::parse($collectionItem->updated_at);
             $collectionItem['timePassed'] = $eventTime->diffForHumans();
-            $collectionItem['userAgentDetails'] = UserAgentDetails::details($collectionItem->useragent);
+            $collectionItem['userAgentDetails'] = UserAgentDetails::details($collectionItem->userAgent);
             $collectionItem['langDetails'] = UserAgentDetails::localeLang($collectionItem->locale);
             $collectionItem['userDetails'] = config('LaravelLogger.defaultUserModel')::find($collectionItem->userId);
 
@@ -111,7 +111,7 @@ class LaravelLoggerController extends BaseController
         $activity = Activity::findOrFail($id);
 
         $userDetails = config('LaravelLogger.defaultUserModel')::find($activity->userId);
-        $userAgentDetails = UserAgentDetails::details($activity->useragent);
+        $userAgentDetails = UserAgentDetails::details($activity->userAgent);
         $ipAddressDetails = IpAddressDetails::checkIP($activity->ipAddress);
         $langDetails = UserAgentDetails::localeLang($activity->locale);
         $eventTime = Carbon::parse($activity->created_at);
@@ -205,7 +205,7 @@ class LaravelLoggerController extends BaseController
         $activity = self::getClearedActvity($id);
 
         $userDetails = config('LaravelLogger.defaultUserModel')::find($activity->userId);
-        $userAgentDetails = UserAgentDetails::details($activity->useragent);
+        $userAgentDetails = UserAgentDetails::details($activity->userAgent);
         $ipAddressDetails = IpAddressDetails::checkIP($activity->ipAddress);
         $langDetails = UserAgentDetails::localeLang($activity->locale);
         $eventTime = Carbon::parse($activity->created_at);

--- a/src/App/Http/Traits/UserAgentDetails.php
+++ b/src/App/Http/Traits/UserAgentDetails.php
@@ -15,7 +15,7 @@ trait UserAgentDetails
     {
         $ua = is_null($ua) ? $_SERVER['HTTP_USER_AGENT'] : $ua;
         // Enumerate all common platforms, this is usually placed in braces (order is important! First come first serve..)
-        $platforms = 'Windows|iPad|iPhone|Macintosh|Android|BlackBerry|Unix|Linux|X11';
+        $platforms = 'Windows|iPad|iPhone|Macintosh|Android|BlackBerry|Unix|Linux|X11|CrOS';
 
         // All browsers except MSIE/Trident and..
         // NOT for browsers that use this syntax: Version/0.xx Browsername

--- a/src/App/Http/Traits/UserAgentDetails.php
+++ b/src/App/Http/Traits/UserAgentDetails.php
@@ -15,7 +15,7 @@ trait UserAgentDetails
     {
         $ua = is_null($ua) ? $_SERVER['HTTP_USER_AGENT'] : $ua;
         // Enumerate all common platforms, this is usually placed in braces (order is important! First come first serve..)
-        $platforms = 'Windows|iPad|iPhone|Macintosh|Android|BlackBerry|Unix|Linux';
+        $platforms = 'Windows|iPad|iPhone|Macintosh|Android|BlackBerry|Unix|Linux|X11';
 
         // All browsers except MSIE/Trident and..
         // NOT for browsers that use this syntax: Version/0.xx Browsername
@@ -53,7 +53,11 @@ trait UserAgentDetails
                 $return['version'] = $ua_array[4];
             }
         } else {
-            return false;
+            $return['platform'] = '-';
+            $return['type'] = '-';
+            $return['renderer'] = '-';
+            $return['browser'] = '-';
+            $return['version'] = '-';
         }
 
         // Replace some browsernames e.g. MSIE -> Internet Explorer
@@ -98,7 +102,7 @@ trait UserAgentDetails
         }
 
         $a = explode(',', $locale);
-        $a = explode(';', $a[1]);
+        $a ??= explode(';', $a[1]);
 
         return $a[0];
     }

--- a/src/resources/views/logger/activity-log-item.blade.php
+++ b/src/resources/views/logger/activity-log-item.blade.php
@@ -123,6 +123,10 @@
             $platformIcon = 'fa-linux';
             break;
 
+        case 'CrOS':
+            $platformIcon = 'fa-chrome';
+            break;
+
         default:
             $platformIcon = 'fa-';
             break;

--- a/src/resources/views/logger/partials/activity-table.blade.php
+++ b/src/resources/views/logger/partials/activity-table.blade.php
@@ -185,6 +185,10 @@ if (Request::is('activity/cleared')) {
                                     $platformIcon = 'fa-linux';
                                     break;
 
+                                case 'CrOS':
+                                    $platformIcon = 'fa-chrome';
+                                    break;
+
                                 default:
                                     $platformIcon = 'fa-';
                                     break;


### PR DESCRIPTION
This PR adds Chrome OS to known user agents and fixes a casing issue that made UserAgentDetails trait to default to $_SERVER['HTTP_USER_AGENT’] in some occurrences. 