### PR TITLE
Add support for custom Activity model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Laravel logger is an activity event logger for your Laravel or Lumen application
 |Records activity User Agent|
 |Records activity Browser Language|
 |Records activity referrer|
+|Customizable activity model|
 |Activity panel dashboard|
 |Individual activity drilldown report dashboard|
 |Activity Drilldown looks up Id Address meta information|
@@ -160,6 +161,7 @@ LARAVEL_LOGGER_ROLES_ENABLED=true
 LARAVEL_LOGGER_ROLES_MIDDLWARE=role:admin
 LARAVEL_LOGGER_MIDDLEWARE_ENABLED=true
 LARAVEL_LOGGER_MIDDLEWARE_EXCEPT=
+LARAVEL_LOGGER_ACTIVITY_MODEL=jeremykenedy\LaravelLogger\App\Models\Activity
 LARAVEL_LOGGER_USER_MODEL=App\User
 LARAVEL_LOGGER_USER_ID_FIELD=id
 LARAVEL_LOGGER_DISABLE_ROUTES=false

--- a/src/App/Http/Controllers/LaravelLoggerController.php
+++ b/src/App/Http/Controllers/LaravelLoggerController.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use jeremykenedy\LaravelLogger\App\Http\Traits\IpAddressDetails;
 use jeremykenedy\LaravelLogger\App\Http\Traits\UserAgentDetails;
-use jeremykenedy\LaravelLogger\App\Models\Activity;
 
 class LaravelLoggerController extends BaseController
 {
@@ -69,14 +68,14 @@ class LaravelLoggerController extends BaseController
     public function showAccessLog(Request $request)
     {
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $activities = Activity::orderBy('created_at', 'desc');
+            $activities = config('laravel-logger.defaultActivityModel')::orderBy('created_at', 'desc');
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
             }
             $activities = $activities->paginate(config('LaravelLogger.loggerPaginationPerPage'));
             $totalActivities = $activities->total();
         } else {
-            $activities = Activity::orderBy('created_at', 'desc');
+            $activities = config('laravel-logger.defaultActivityModel')::orderBy('created_at', 'desc');
 
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
@@ -108,7 +107,7 @@ class LaravelLoggerController extends BaseController
      */
     public function showAccessLogEntry(Request $request, $id)
     {
-        $activity = Activity::findOrFail($id);
+        $activity = config('laravel-logger.defaultActivityModel')::findOrFail($id);
 
         $userDetails = config('LaravelLogger.defaultUserModel')::find($activity->userId);
         $userAgentDetails = UserAgentDetails::details($activity->userAgent);
@@ -118,12 +117,12 @@ class LaravelLoggerController extends BaseController
         $timePassed = $eventTime->diffForHumans();
 
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $userActivities = Activity::where('userId', $activity->userId)
+            $userActivities = config('laravel-logger.defaultActivityModel')::where('userId', $activity->userId)
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
             $totalUserActivities = $userActivities->total();
         } else {
-            $userActivities = Activity::where('userId', $activity->userId)
+            $userActivities = config('laravel-logger.defaultActivityModel')::where('userId', $activity->userId)
             ->orderBy('created_at', 'desc')
             ->get();
             $totalUserActivities = $userActivities->count();
@@ -155,7 +154,7 @@ class LaravelLoggerController extends BaseController
      */
     public function clearActivityLog(Request $request)
     {
-        $activities = Activity::all();
+        $activities = config('laravel-logger.defaultActivityModel')::all();
         foreach ($activities as $activity) {
             $activity->delete();
         }
@@ -171,12 +170,12 @@ class LaravelLoggerController extends BaseController
     public function showClearedActivityLog()
     {
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $activities = Activity::onlyTrashed()
+            $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
             $totalActivities = $activities->total();
         } else {
-            $activities = Activity::onlyTrashed()
+            $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()
             ->orderBy('created_at', 'desc')
             ->get();
             $totalActivities = $activities->count();
@@ -233,7 +232,7 @@ class LaravelLoggerController extends BaseController
      */
     private static function getClearedActvity($id)
     {
-        $activity = Activity::onlyTrashed()->where('id', $id)->get();
+        $activity = config('laravel-logger.defaultActivityModel')::onlyTrashed()->where('id', $id)->get();
         if (count($activity) != 1) {
             return abort(404);
         }
@@ -250,7 +249,7 @@ class LaravelLoggerController extends BaseController
      */
     public function destroyActivityLog(Request $request)
     {
-        $activities = Activity::onlyTrashed()->get();
+        $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()->get();
         foreach ($activities as $activity) {
             $activity->forceDelete();
         }
@@ -267,7 +266,7 @@ class LaravelLoggerController extends BaseController
      */
     public function restoreClearedActivityLog(Request $request)
     {
-        $activities = Activity::onlyTrashed()->get();
+        $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()->get();
         foreach ($activities as $activity) {
             $activity->restore();
         }

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Validator;
 use Jaybizzle\LaravelCrawlerDetect\Facades\LaravelCrawlerDetect as Crawler;
-use jeremykenedy\LaravelLogger\App\Models\Activity;
 
 trait ActivityLogger
 {
@@ -73,7 +72,7 @@ trait ActivityLogger
         ];
 
         // Validation Instance
-        $validator = Validator::make($data, Activity::rules());
+        $validator = Validator::make($data, config('laravel-logger.defaultActivityModel')::rules());
         if ($validator->fails()) {
             $errors = self::prepareErrorMessage($validator->errors(), $data);
             if (config('LaravelLogger.logDBActivityLogFailuresToFile')) {
@@ -93,7 +92,7 @@ trait ActivityLogger
      */
     private static function storeActivity($data)
     {
-        Activity::create([
+        config('laravel-logger.defaultActivityModel')::create([
             'description'   => $data['description'],
             'userType'      => $data['userType'],
             'userId'        => $data['userId'],

--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -64,7 +64,7 @@ return [
     */
 
     'defaultActivityModel' => env('LARAVEL_LOGGER_ACTIVITY_MODEL', 'jeremykenedy\LaravelLogger\App\Models\Activity'),
-    'defaultUserModel' => env('LARAVEL_LOGGER_USER_MODEL', 'App\User'),
+    'defaultUserModel'     => env('LARAVEL_LOGGER_USER_MODEL', 'App\User'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -59,10 +59,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Laravel Default User Model
+    | Laravel Default Models
     |--------------------------------------------------------------------------
     */
 
+    'defaultActivityModel' => env('LARAVEL_LOGGER_ACTIVITY_MODEL', 'jeremykenedy\LaravelLogger\App\Models\Activity'),
     'defaultUserModel' => env('LARAVEL_LOGGER_USER_MODEL', 'App\User'),
 
     /*


### PR DESCRIPTION
Re. #94 this PR add the ability to customize default Activity model.

As per @jeremykenedy demands in the referred issue:

> 100% backwards compatible...

It was developed in Laravel 5.8 and tested up to Laravel 8. It should work all the way down to Laravel 5.1 tho.

> ...with no further configuration needed

Unable to comply as there's the need to choose the desired Activity model with
```php
config('laravel-logger.defaultActivityModel')
```

> ...and done cleanly in Laravel conventions.

Done.

I hope this PR find its way to master. Thanks again for the great package, @jeremykenedy.