### PR TITLE
Add support for activity details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Laravel logger is an activity event logger for your Laravel or Lumen application
 |Routing Events can recording using middleware|
 |Records activity timestamps|
 |Records activity description|
+|Records activity details (optional)|
 |Records activity user type with crawler detection.|
 |Records activity Method|
 |Records activity Route|
@@ -216,20 +217,25 @@ When using the trait you can customize the event description.
 To use the trait:
 1. Include the call in the head of your class file:
 
-```php
-    use jeremykenedy\LaravelLogger\App\Http\Traits\ActivityLogger;
-```
+    ```php
+        use jeremykenedy\LaravelLogger\App\Http\Traits\ActivityLogger;
+    ```
 
 2. Include the trait call in the opening of your class:
 
-```php
-    use ActivityLogger;
-```
+    ```php
+        use ActivityLogger;
+    ```
 
 3. You can record the activity my calling the traits method:
-```
-    ActivityLogger::activity("Logging this activity.");
-```
+    ```
+        ActivityLogger::activity("Logging this activity.");
+    ```
+
+    Or as bellow to include extended activity details:
+    ```
+        ActivityLogger::activity("Logging this activity.", "Additional activity details.");
+    ```
 
 ### Routes
 ##### Laravel Activity Dashbaord Routes

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -14,11 +14,12 @@ trait ActivityLogger
     /**
      * Laravel Logger Log Activity.
      *
-     * @param string $description
+     * @param null $description
+     * @param null $details
      *
      * @return void
      */
-    public static function activity($description = null)
+    public static function activity($description = null, $details = null)
     {
         $userType = trans('LaravelLogger::laravel-logger.userTypes.guest');
         $userId = null;
@@ -62,6 +63,7 @@ trait ActivityLogger
 
         $data = [
             'description'   => $description,
+            'details'       => $details,
             'userType'      => $userType,
             'userId'        => $userId,
             'route'         => Request::fullUrl(),
@@ -95,6 +97,7 @@ trait ActivityLogger
     {
         Activity::create([
             'description'   => $data['description'],
+            'details'       => $data['details'],
             'userType'      => $data['userType'],
             'userId'        => $data['userId'],
             'route'         => $data['route'],

--- a/src/App/Models/Activity.php
+++ b/src/App/Models/Activity.php
@@ -57,6 +57,7 @@ class Activity extends Model
      */
     protected $fillable = [
         'description',
+        'details',
         'userType',
         'userId',
         'route',
@@ -69,6 +70,7 @@ class Activity extends Model
 
     protected $casts = [
         'description'   => 'string',
+        'details'       => 'string',
         'user'          => 'integer',
         'route'         => 'string',
         'ipAddress'     => 'string',
@@ -134,6 +136,7 @@ class Activity extends Model
         return array_merge(
             [
                 'description'   => 'required|string',
+                'details'       => 'nullable|string',
                 'userType'      => 'required|string',
                 'userId'        => 'nullable|integer',
                 'route'         => 'nullable|'.$route_url_check,

--- a/src/database/migrations/2017_11_04_103444_create_laravel_logger_activity_table.php
+++ b/src/database/migrations/2017_11_04_103444_create_laravel_logger_activity_table.php
@@ -23,6 +23,7 @@ class CreateLaravelLoggerActivityTable extends Migration
             Schema::connection($connection)->create($table, function (Blueprint $table) {
                 $table->increments('id');
                 $table->longText('description');
+                $table->longText('details')->nullable();
                 $table->string('userType');
                 $table->integer('userId')->nullable();
                 $table->longText('route')->nullable();

--- a/src/resources/lang/de/laravel-logger.php
+++ b/src/resources/lang/de/laravel-logger.php
@@ -86,6 +86,7 @@ return [
                 'id'            => 'Aktivitätslog ID:',
                 'ip'            => 'IP Adresse',
                 'description'   => 'Beschreibung',
+                'details'       => 'Einzelheiten',
                 'userType'      => 'Nutzertyp',
                 'userId'        => 'Nutzer ID',
                 'route'         => 'Route',
@@ -106,6 +107,10 @@ return [
                 'userSignupIp'  => 'Anmelde Ip',
                 'userCreatedAt' => 'Erstellt',
                 'userUpdatedAt' => 'Bearbeitet',
+            ],
+
+            'fields' => [
+                'none' => 'Keiner',
             ],
         ],
 

--- a/src/resources/lang/en/laravel-logger.php
+++ b/src/resources/lang/en/laravel-logger.php
@@ -86,6 +86,7 @@ return [
                 'id'            => 'Activity Log ID:',
                 'ip'            => 'Ip Address',
                 'description'   => 'Description',
+                'details'       => 'Details',
                 'userType'      => 'User Type',
                 'userId'        => 'User Id',
                 'route'         => 'Route',
@@ -106,6 +107,10 @@ return [
                 'userSignupIp'  => 'Signup Ip',
                 'userCreatedAt' => 'Created',
                 'userUpdatedAt' => 'Updated',
+            ],
+
+            'fields' => [
+                'none' => 'None',
             ],
         ],
 

--- a/src/resources/lang/fr/laravel-logger.php
+++ b/src/resources/lang/fr/laravel-logger.php
@@ -84,6 +84,7 @@ return [
                 'id'            => 'Activité Id :',
                 'ip'            => 'Adresse Ip',
                 'description'   => 'Description',
+                'details'       => 'Détails',
                 'userType'      => 'Type Utilisateur',
                 'userId'        => 'Id Utilisateur',
                 'route'         => 'Route',
@@ -104,6 +105,10 @@ return [
                 'userSignupIp'  => 'Inscription Ip',
                 'userCreatedAt' => 'Créé le',
                 'userUpdatedAt' => 'Actualisé le',
+            ],
+
+            'fields' => [
+                'none' => 'Aucun',
             ],
         ],
 

--- a/src/resources/views/logger/activity-log-item.blade.php
+++ b/src/resources/views/logger/activity-log-item.blade.php
@@ -191,6 +191,8 @@
                                         <dd>{{$activity->id}}</dd>
                                         <dt>{!! trans('LaravelLogger::laravel-logger.drilldown.list-group.labels.description') !!}</dt>
                                         <dd>{{$activity->description}}</dd>
+                                        <dt>{!! trans('LaravelLogger::laravel-logger.drilldown.list-group.labels.details') !!}</dt>
+                                        <dd>@if($activity->details){{$activity->details}}@else{!! trans('LaravelLogger::laravel-logger.drilldown.list-group.fields.none') !!}@endif</dd>
                                         <dt>{!! trans('LaravelLogger::laravel-logger.drilldown.list-group.labels.route') !!}</dt>
                                         <dd>
                                             <a href="@if($activity->route != '/')/@endif{{$activity->route}}">


### PR DESCRIPTION
Although the Activity model holds a description field, this field is used in index and search. If it holds many detailed information about the activity being logged, it could break index layout and add additional stress upon search.

To avoid that, a detail field is added. This new, optional field can hold any additional information required to better describe the activity. This is particularly useful to provide a fully functional auditing log as one can now add details for the entire data changed by the activity while keeping description as narrow as possible.

As the field is optional, the ActivityLogger trait could be used as usual, or include a second parameter with all the desired details to be logged. No additional configuration is required for this to work.

I'm not a native speaker of any of the supported languages in this package, but I've included translations for them. Fell free to change that as needed.

I hope this PR find its way to master. Thanks again for the great package, @jeremykenedy.