### PR TITLE
Compatibility PHP 7.3; remove null coalescing assignment operator use.

### DIFF
--- a/src/App/Http/Traits/UserAgentDetails.php
+++ b/src/App/Http/Traits/UserAgentDetails.php
@@ -102,7 +102,7 @@ trait UserAgentDetails
         }
 
         $a = explode(',', $locale);
-        $a ??= explode(';', $a[1]);
+        $a = $a ?? explode(';', $a[1]);
 
         return $a[0];
     }


### PR DESCRIPTION
Unpacked null coalescing assignment operator since it is a PHP7.4 feature and this package still lists PHP7.3 as minimum requirement.

* https://www.php.net/manual/en/migration74.new-features.php
* https://wiki.php.net/rfc/null_coalesce_equal_operator