### PR TITLE
Add localization for listener activities

### DIFF
--- a/src/App/Listeners/LogAuthenticated.php
+++ b/src/App/Listeners/LogAuthenticated.php
@@ -29,7 +29,7 @@ class LogAuthenticated
     public function handle(Authenticated $event)
     {
         if (config('LaravelLogger.logAllAuthEvents')) {
-            ActivityLogger::activity('Authenticated Activity');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.auth'));
         }
     }
 }

--- a/src/App/Listeners/LogAuthenticationAttempt.php
+++ b/src/App/Listeners/LogAuthenticationAttempt.php
@@ -29,7 +29,7 @@ class LogAuthenticationAttempt
     public function handle(Attempting $event)
     {
         if (config('LaravelLogger.logAuthAttempts')) {
-            ActivityLogger::activity('Authenticated Attempt');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.attempt'));
         }
     }
 }

--- a/src/App/Listeners/LogFailedLogin.php
+++ b/src/App/Listeners/LogFailedLogin.php
@@ -29,7 +29,7 @@ class LogFailedLogin
     public function handle(Failed $event)
     {
         if (config('LaravelLogger.logFailedAuthAttempts')) {
-            ActivityLogger::activity('Failed Login Attempt');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.failed'));
         }
     }
 }

--- a/src/App/Listeners/LogLockout.php
+++ b/src/App/Listeners/LogLockout.php
@@ -29,7 +29,7 @@ class LogLockout
     public function handle(Lockout $event)
     {
         if (config('LaravelLogger.logLockOut')) {
-            ActivityLogger::activity('Locked Out');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.lockout'));
         }
     }
 }

--- a/src/App/Listeners/LogPasswordReset.php
+++ b/src/App/Listeners/LogPasswordReset.php
@@ -29,7 +29,7 @@ class LogPasswordReset
     public function handle(PasswordReset $event)
     {
         if (config('LaravelLogger.logPasswordReset')) {
-            ActivityLogger::activity('Reset Password');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.reset'));
         }
     }
 }

--- a/src/App/Listeners/LogSuccessfulLogin.php
+++ b/src/App/Listeners/LogSuccessfulLogin.php
@@ -29,7 +29,7 @@ class LogSuccessfulLogin
     public function handle(Login $event)
     {
         if (config('LaravelLogger.logSuccessfulLogin')) {
-            ActivityLogger::activity('Logged In');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.login'));
         }
     }
 }

--- a/src/App/Listeners/LogSuccessfulLogout.php
+++ b/src/App/Listeners/LogSuccessfulLogout.php
@@ -29,7 +29,7 @@ class LogSuccessfulLogout
     public function handle(Logout $event)
     {
         if (config('LaravelLogger.logSuccessfulLogout')) {
-            ActivityLogger::activity('Logged Out');
+            ActivityLogger::activity(trans('LaravelLogger::laravel-logger.listenerTypes.logout'));
         }
     }
 }

--- a/src/resources/lang/en/laravel-logger.php
+++ b/src/resources/lang/en/laravel-logger.php
@@ -21,6 +21,16 @@ return [
         'crawled'    => 'crawled',
     ],
 
+    'listenerTypes' => [
+        'auth'       => 'Authenticated Activity',
+        'attempt'    => 'Authenticated Attempt',
+        'failed'     => 'Failed Login Attempt',
+        'lockout'    => 'Locked Out',
+        'reset'      => 'Reset Password',
+        'login'      => 'Logged In',
+        'logout'     => 'Logged Out',
+    ],
+
     'tooltips' => [
         'viewRecord' => 'View Record Details',
     ],


### PR DESCRIPTION
Laravel Activity Logger already provide almost complete localization support. There's only one area where localization couldn't happen: event listener activities ('logged in', 'logged out' and such). This PR is an attempt to provide this missing functionality to such a great package.