### PR TITLE
Allow unauthenticated access to logger activity screens

### DIFF
--- a/src/App/Http/Controllers/LaravelLoggerController.php
+++ b/src/App/Http/Controllers/LaravelLoggerController.php
@@ -28,7 +28,10 @@ class LaravelLoggerController extends BaseController
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->_authRequired = config('LaravelLogger.authRequired');
+        if ($this->_authRequired) {
+            $this->middleware('auth');
+        }
 
         $this->_rolesEnabled = config('LaravelLogger.rolesEnabled');
         $this->_rolesMiddlware = config('LaravelLogger.rolesMiddlware');

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -7,8 +7,15 @@
 |
 */
 
-Route::group(['prefix' => 'activity', 'namespace' => 'jeremykenedy\LaravelLogger\App\Http\Controllers', 'middleware' => ['web', 'auth', 'activity']], function () {
+Route::group(['prefix' => 'activity', 'namespace' => 'jeremykenedy\LaravelLogger\App\Http\Controllers', 'middleware' => (function () {
+    $middleware = ['web', 'activity'];
 
+    if (config('LaravelLogger.authRequired', true)) {
+        $middleware[] = 'auth';
+    }
+
+    return $middleware;
+})], function () {
     // Dashboards
     Route::get('/', 'LaravelLoggerController@showAccessLog')->name('activity');
     Route::get('/cleared', ['uses' => 'LaravelLoggerController@showClearedActivityLog'])->name('cleared');


### PR DESCRIPTION
Hello,

This PR adds an option to the configuration to not have an authenticated user to access activity routes.

Sometimes it is not appropriate to manage access to this data through an application user, even using a specific role for authorization. 

With this option, it will be possible to choose another mode of protection, I am thinking in particular of access rules in apache, nginx or iis directly.
