### PR TITLE
Not writing the model and userid record correctly

### DIFF
--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -23,10 +23,29 @@ trait ActivityLogger
         $userType = trans('LaravelLogger::laravel-logger.userTypes.guest');
         $userId = null;
 
-        if (Auth::check()) {
+        $model = config('laravel-logger.defaultUserModel');
+        
+        if ($model == "App\Models\Admin")
+        {
+            $check = \Auth::guard('admin')->check();
+        }
+        else
+        {
+            $check = \Auth::check();
+        }
+        
+        if ($check) {
             $userType = trans('LaravelLogger::laravel-logger.userTypes.registered');
             $userIdField = config('LaravelLogger.defaultUserIDField');
-            $userId = Request::user()->{$userIdField};
+            
+            if ($model == "App\Models\Admin")
+            {
+                $userId = \Auth::guard('admin')->user()->{$userIdField};
+            }
+            else{
+                $userId = Request::user()->{$userIdField};
+            }
+            
         }
 
         if (Crawler::isCrawler()) {


### PR DESCRIPTION
The activity does not print according to the model set while typing, it is only based on the User model. For example, the admin model is entered.