### PR TITLE
Fix bug where Request::is() is not a static method

### DIFF
--- a/src/resources/views/logger/partials/activity-table.blade.php
+++ b/src/resources/views/logger/partials/activity-table.blade.php
@@ -9,7 +9,7 @@ if (isset($hoverable) && $hoverable === true) {
     $hoverable = false;
 }
 
-if (\Illuminate\Http\Request::is('activity/cleared')) {
+if (request()->is('activity/cleared')) {
     $prependUrl = '/activity/cleared/log/';
 }
 
@@ -55,7 +55,7 @@ if (\Illuminate\Http\Request::is('activity/cleared')) {
                     <i class="fa fa-laptop fa-fw" aria-hidden="true"></i>
                     {!! trans('LaravelLogger::laravel-logger.dashboard.labels.agent') !!}
                 </th>
-                @if(\Illuminate\Http\Request::is('activity/cleared'))
+                @if(request()->is('activity/cleared'))
                     <th>
                         <i class="fa fa-trash-o fa-fw" aria-hidden="true"></i>
                         {!! trans('LaravelLogger::laravel-logger.dashboard.labels.deleteDate') !!}
@@ -242,7 +242,7 @@ if (\Illuminate\Http\Request::is('activity/cleared')) {
                             </small>
                         </sup>
                     </td>
-                    @if(\Illuminate\Http\Request::is('activity/cleared'))
+                    @if(request()->is('activity/cleared'))
                         <td>
                             {{ $activity->deleted_at }}
                         </td>


### PR DESCRIPTION
PHP error `Non-static method Illuminate\Http\Request::is() cannot be called statically` occurs on PHP 8.1.14 with Laravel 9.48.0.

Fixes https://github.com/jeremykenedy/laravel-logger/issues/150