### PR TITLE
fix: config key

### DIFF
--- a/src/App/Http/Controllers/LaravelLoggerController.php
+++ b/src/App/Http/Controllers/LaravelLoggerController.php
@@ -68,14 +68,14 @@ class LaravelLoggerController extends BaseController
     public function showAccessLog(Request $request)
     {
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $activities = config('laravel-logger.defaultActivityModel')::orderBy('created_at', 'desc');
+            $activities = config('LaravelLogger.defaultActivityModel')::orderBy('created_at', 'desc');
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
             }
             $activities = $activities->paginate(config('LaravelLogger.loggerPaginationPerPage'))->withQueryString();
             $totalActivities = $activities->total();
         } else {
-            $activities = config('laravel-logger.defaultActivityModel')::orderBy('created_at', 'desc');
+            $activities = config('LaravelLogger.defaultActivityModel')::orderBy('created_at', 'desc');
 
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
@@ -107,7 +107,7 @@ class LaravelLoggerController extends BaseController
      */
     public function showAccessLogEntry(Request $request, $id)
     {
-        $activity = config('laravel-logger.defaultActivityModel')::findOrFail($id);
+        $activity = config('LaravelLogger.defaultActivityModel')::findOrFail($id);
 
         $userDetails = config('LaravelLogger.defaultUserModel')::find($activity->userId);
         $userAgentDetails = UserAgentDetails::details($activity->userAgent);
@@ -117,12 +117,12 @@ class LaravelLoggerController extends BaseController
         $timePassed = $eventTime->diffForHumans();
 
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $userActivities = config('laravel-logger.defaultActivityModel')::where('userId', $activity->userId)
+            $userActivities = config('LaravelLogger.defaultActivityModel')::where('userId', $activity->userId)
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
             $totalUserActivities = $userActivities->total();
         } else {
-            $userActivities = config('laravel-logger.defaultActivityModel')::where('userId', $activity->userId)
+            $userActivities = config('LaravelLogger.defaultActivityModel')::where('userId', $activity->userId)
             ->orderBy('created_at', 'desc')
             ->get();
             $totalUserActivities = $userActivities->count();
@@ -154,7 +154,7 @@ class LaravelLoggerController extends BaseController
      */
     public function clearActivityLog(Request $request)
     {
-        $activities = config('laravel-logger.defaultActivityModel')::all();
+        $activities = config('LaravelLogger.defaultActivityModel')::all();
         foreach ($activities as $activity) {
             $activity->delete();
         }
@@ -170,12 +170,12 @@ class LaravelLoggerController extends BaseController
     public function showClearedActivityLog()
     {
         if (config('LaravelLogger.loggerPaginationEnabled')) {
-            $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()
+            $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
             $totalActivities = $activities->total();
         } else {
-            $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()
+            $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()
             ->orderBy('created_at', 'desc')
             ->get();
             $totalActivities = $activities->count();
@@ -232,7 +232,7 @@ class LaravelLoggerController extends BaseController
      */
     private static function getClearedActvity($id)
     {
-        $activity = config('laravel-logger.defaultActivityModel')::onlyTrashed()->where('id', $id)->get();
+        $activity = config('LaravelLogger.defaultActivityModel')::onlyTrashed()->where('id', $id)->get();
         if (count($activity) != 1) {
             return abort(404);
         }
@@ -249,7 +249,7 @@ class LaravelLoggerController extends BaseController
      */
     public function destroyActivityLog(Request $request)
     {
-        $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()->get();
+        $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()->get();
         foreach ($activities as $activity) {
             $activity->forceDelete();
         }
@@ -266,7 +266,7 @@ class LaravelLoggerController extends BaseController
      */
     public function restoreClearedActivityLog(Request $request)
     {
-        $activities = config('laravel-logger.defaultActivityModel')::onlyTrashed()->get();
+        $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()->get();
         foreach ($activities as $activity) {
             $activity->restore();
         }

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -82,7 +82,7 @@ trait ActivityLogger
         ];
 
         // Validation Instance
-        $validator = Validator::make($data, config('laravel-logger.defaultActivityModel')::rules());
+        $validator = Validator::make($data, config('LaravelLogger.defaultActivityModel')::rules());
         if ($validator->fails()) {
             $errors = self::prepareErrorMessage($validator->errors(), $data);
             if (config('LaravelLogger.logDBActivityLogFailuresToFile')) {
@@ -102,7 +102,7 @@ trait ActivityLogger
      */
     private static function storeActivity($data)
     {
-        config('laravel-logger.defaultActivityModel')::create([
+        config('LaravelLogger.defaultActivityModel')::create([
             'description'   => $data['description'],
             'details'       => $data['details'],
             'userType'      => $data['userType'],


### PR DESCRIPTION
Service provider calls of `mergeConfigFrom` use key `LaravelLogger`

There are multiple keys in use: `config('LaravelLogger')` and `config('laravel-logger')`. The last causes errors such as:

`Class name must be a valid object or a string` (`vendor/jeremykenedy/laravel-logger/src/App/Http/Traits/ActivityLogger.php:85`)

Related: https://github.com/jeremykenedy/laravel-logger/pull/109