### PR TITLE
The $dates array for mutating attributes is removed in Laravel 10; use $casts instead.

### DIFF
--- a/src/App/Models/Activity.php
+++ b/src/App/Models/Activity.php
@@ -40,17 +40,6 @@ class Activity extends Model
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
-    ];
-
-    /**
      * Fillable fields for a Profile.
      *
      * @var array
@@ -68,7 +57,15 @@ class Activity extends Model
         'methodType',
     ];
 
+    /**
+     * The attributes that should be mutated.
+     *
+     * @var array
+     */
     protected $casts = [
+        'created_at'    => 'datetime',
+        'updated_at'    => 'datetime',
+        'deleted_at'    => 'datetime',
         'description'   => 'string',
         'details'       => 'string',
         'user'          => 'integer',


### PR DESCRIPTION
Regarding Laravel 10 upgrade:

* https://laravel.com/docs/10.x/upgrade#model-dates-property

> The Eloquent model's deprecated $dates property has been removed. 
> Your application should now use the $casts property: [...]
