### PR TITLE
Resolve Calling static trait method  deprecated warnings

### DIFF
--- a/src/App/Http/Middleware/LogActivity.php
+++ b/src/App/Http/Middleware/LogActivity.php
@@ -21,7 +21,7 @@ class LogActivity
     public function handle($request, Closure $next, $description = null)
     {
         if (config('LaravelLogger.loggerMiddlewareEnabled') && $this->shouldLog($request)) {
-            ActivityLogger::activity($description);
+            $this->activity($description);
         }
 
         return $next($request);

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -18,7 +18,7 @@ trait ActivityLogger
      *
      * @return void
      */
-    public static function activity($description = null, $details = null)
+    public function activity($description = null, $details = null)
     {
         $userType = trans('LaravelLogger::laravel-logger.userTypes.guest');
         $userId = null;


### PR DESCRIPTION
This will take care of the warning:

`Calling static trait method jeremykenedy\LaravelLogger\App\Http\Traits\ActivityLogger::activity is deprecated, it should only be called on a class using the trait in /vendor/jeremykenedy/laravel-logger/src/App/Http/Middleware/LogActivity.php on line 24`