### PR TITLE
Implement a high performance paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ LARAVEL_LOGGER_USER_MODEL=App\User
 LARAVEL_LOGGER_USER_ID_FIELD=id
 LARAVEL_LOGGER_DISABLE_ROUTES=false
 LARAVEL_LOGGER_PAGINATION_ENABLED=true
+LARAVEL_LOGGER_CURSOR_PAGINATION_ENABLED=false
 LARAVEL_LOGGER_PAGINATION_PER_PAGE=25
 LARAVEL_LOGGER_DATATABLES_ENABLED=true
 LARAVEL_LOGGER_ENABLE_SEARCH=true
@@ -285,6 +286,10 @@ Route::group(['prefix' => 'activity', 'namespace' => 'jeremykenedy\LaravelLogger
 ### Search
 
 adding dynamic search fields (description , user, URL , method and ip address)
+
+### High Performance Paginator
+
+When dealing with millions activity records, default behavior of not paginate records or [Laravel's paginator](https://laravel.com/docs/pagination#paginating-eloquent-results) (enabled `LARAVEL_LOGGER_PAGINATION_ENABLED=true`) may lead to huge performance penalties. For that use case you may set `LARAVEL_LOGGER_CURSOR_PAGINATION_ENABLED=true` to enable [Laravel's Cursor Pagination](https://laravel.com/docs/pagination#cursor-pagination) feature. This will heavily improve Laravel Logger page loading time. If you choose to do so it's advisable to read [Cursor vs. Offset Pagination](https://laravel.com/docs/pagination#cursor-vs-offset-pagination) section on Laravel's documentation to get acquainted with Cursor Pagination limitations.
 
 ##### .env file
 add these configurations to your .env file to control the logging search

--- a/src/App/Http/Controllers/LaravelLoggerController.php
+++ b/src/App/Http/Controllers/LaravelLoggerController.php
@@ -67,7 +67,14 @@ class LaravelLoggerController extends BaseController
      */
     public function showAccessLog(Request $request)
     {
-        if (config('LaravelLogger.loggerPaginationEnabled')) {
+        if (config('LaravelLogger.loggerCursorPaginationEnabled')) {
+            $activities = config('LaravelLogger.defaultActivityModel')::orderBy('created_at', 'desc');
+            if (config('LaravelLogger.enableSearch')) {
+                $activities = $this->searchActivityLog($activities, $request);
+            }
+            $activities = $activities->cursorPaginate(config('LaravelLogger.loggerPaginationPerPage'))->withQueryString();
+            $totalActivities = 0;
+        } elseif (config('LaravelLogger.loggerPaginationEnabled')) {
             $activities = config('LaravelLogger.defaultActivityModel')::orderBy('created_at', 'desc');
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
@@ -76,7 +83,6 @@ class LaravelLoggerController extends BaseController
             $totalActivities = $activities->total();
         } else {
             $activities = config('LaravelLogger.defaultActivityModel')::orderBy('created_at', 'desc');
-
             if (config('LaravelLogger.enableSearch')) {
                 $activities = $this->searchActivityLog($activities, $request);
             }
@@ -122,7 +128,12 @@ class LaravelLoggerController extends BaseController
         $eventTime = Carbon::parse($activity->created_at);
         $timePassed = $eventTime->diffForHumans();
 
-        if (config('LaravelLogger.loggerPaginationEnabled')) {
+        if (config('LaravelLogger.loggerCursorPaginationEnabled')) {
+            $userActivities = config('LaravelLogger.defaultActivityModel')::where('userId', $activity->userId)
+                ->orderBy('created_at', 'desc')
+                ->cursorPaginate(config('LaravelLogger.loggerPaginationPerPage'));
+            $totalUserActivities = 0;
+        } elseif (config('LaravelLogger.loggerPaginationEnabled')) {
             $userActivities = config('LaravelLogger.defaultActivityModel')::where('userId', $activity->userId)
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
@@ -175,7 +186,12 @@ class LaravelLoggerController extends BaseController
      */
     public function showClearedActivityLog()
     {
-        if (config('LaravelLogger.loggerPaginationEnabled')) {
+        if (config('LaravelLogger.loggerCursorPaginationEnabled')) {
+            $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()
+                ->orderBy('created_at', 'desc')
+                ->paginate(config('LaravelLogger.loggerPaginationPerPage'));
+            $totalActivities = 0;
+        } elseif (config('LaravelLogger.loggerPaginationEnabled')) {
             $activities = config('LaravelLogger.defaultActivityModel')::onlyTrashed()
             ->orderBy('created_at', 'desc')
             ->paginate(config('LaravelLogger.loggerPaginationPerPage'));

--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -90,6 +90,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'loggerPaginationEnabled' => env('LARAVEL_LOGGER_PAGINATION_ENABLED', true),
+    'loggerCursorPaginationEnabled' => env('LARAVEL_LOGGER_CURSOR_PAGINATION_ENABLED', false),
     'loggerPaginationPerPage' => env('LARAVEL_LOGGER_PAGINATION_PER_PAGE', 25),
 
     /*

--- a/src/resources/views/logger/activity-log-cleared.blade.php
+++ b/src/resources/views/logger/activity-log-cleared.blade.php
@@ -71,9 +71,11 @@
                         <div style="display: flex; justify-content: space-between; align-items: center;">
                             <span>
                                 {!! trans('LaravelLogger::laravel-logger.dashboardCleared.title') !!}
-                                <sup class="label">
-                                    {{ $totalActivities }} {!! trans('LaravelLogger::laravel-logger.dashboardCleared.subtitle') !!}
-                                </sup>
+                                @if(! config('LaravelLogger.loggerCursorPaginationEnabled'))
+                                    <sup class="label">
+                                        {{ $totalActivities }} {!! trans('LaravelLogger::laravel-logger.dashboardCleared.subtitle') !!}
+                                    </sup>
+                                @endif
                             </span>
                             <div class="btn-group pull-right btn-group-xs">
                                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/src/resources/views/logger/activity-log-item.blade.php
+++ b/src/resources/views/logger/activity-log-item.blade.php
@@ -339,9 +339,11 @@
                         <ul class="list-group">
                             <li class="list-group-item list-group-item-info">
                                 {!! trans('LaravelLogger::laravel-logger.drilldown.title-user-activity') !!}
-                                <span class="badge">
-                                    {{ $totalUserActivities }} {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
-                                </span>
+                                @if(! config('LaravelLogger.loggerCursorPaginationEnabled'))
+                                    <span class="badge">
+                                        {{ $totalUserActivities }} {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
+                                    </span>
+                                @endif
                             </li>
                             <li class="list-group-item">
                                 @include('LaravelLogger::logger.partials.activity-table', ['activities' => $userActivities])

--- a/src/resources/views/logger/activity-log.blade.php
+++ b/src/resources/views/logger/activity-log.blade.php
@@ -81,11 +81,13 @@
 
                             <span>
                                 {!! trans('LaravelLogger::laravel-logger.dashboard.title') !!}
-                                <small>
-                                    <sup class="label label-default">
-                                        {{ $totalActivities }} {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
-                                    </sup>
-                                </small>
+                                @if(! config('LaravelLogger.loggerCursorPaginationEnabled'))
+                                    <small>
+                                        <sup class="label label-default">
+                                            {{ $totalActivities }} {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
+                                        </sup>
+                                    </small>
+                                @endif
                             </span>
 
                             <div class="btn-group pull-right btn-group-xs">
@@ -120,12 +122,14 @@
 
                             @else
                             {!! trans('LaravelLogger::laravel-logger.dashboard.title') !!}
-                            <span class="pull-right label label-default">
-                                {{ $totalActivities }}
-                                <span class="hidden-sms">
-                                    {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
-                                </span>
-                            </span>
+                                @if(! config('LaravelLogger.loggerCursorPaginationEnabled'))
+                                    <span class="pull-right label label-default">
+                                        {{ $totalActivities }}
+                                        <span class="hidden-sms">
+                                            {!! trans('LaravelLogger::laravel-logger.dashboard.subtitle') !!}
+                                        </span>
+                                    </span>
+                                @endif
                             @endif
 
                         </div>

--- a/src/resources/views/logger/partials/activity-table.blade.php
+++ b/src/resources/views/logger/partials/activity-table.blade.php
@@ -253,7 +253,13 @@ if (request()->is('activity/cleared')) {
     </table>
 </div>
 
-@if(config('LaravelLogger.loggerPaginationEnabled'))
+@if(config('LaravelLogger.loggerCursorPaginationEnabled'))
+    <div class="text-center">
+        <div class="d-flex justify-content-center">
+            {!! $activities->links() !!}
+        </div>
+    </div>
+@elseif(config('LaravelLogger.loggerPaginationEnabled'))
     <div class="text-center">
         <div class="d-flex justify-content-center">
             {!! $activities->links('vendor.pagination.bootstrap-4') !!}


### PR DESCRIPTION
When dealing with millions activity records, the default behavior to not paginate records or [Laravel's paginator](https://laravel.com/docs/pagination#paginating-eloquent-results) (enabled by `LARAVEL_LOGGER_PAGINATION_ENABLED=true`) may lead to huge performance penalties.

For that use case, this PR implements `LARAVEL_LOGGER_CURSOR_PAGINATION_ENABLED=true` to enable [Laravel's Cursor Pagination](https://laravel.com/docs/pagination#cursor-pagination) feature. This heavily improves Laravel Logger page loading time.

When enabled, it's advisable to read [Cursor vs. Offset Pagination](https://laravel.com/docs/pagination#cursor-vs-offset-pagination) section on Laravel's documentation to get acquainted with Cursor Pagination limitations.