### PR TITLE
GeoPlugin configuration settings.

### DIFF
--- a/src/App/Http/Traits/IpAddressDetails.php
+++ b/src/App/Http/Traits/IpAddressDetails.php
@@ -38,8 +38,9 @@ trait IpAddressDetails
             'NA' => 'North America',
             'SA' => 'South America',
         ];
-        if (filter_var($ip, FILTER_VALIDATE_IP) && in_array($purpose, $support)) {
-            $ipdat = @json_decode(file_get_contents('http://www.geoplugin.net/json.gp?ip='.$ip));
+        if (config('LaravelLogger.enableGeoPlugin', true) && filter_var($ip, FILTER_VALIDATE_IP) && in_array($purpose, $support)) {
+            $geopluginUrl = config('LaravelLogger.geoPluginUrl', 'http://www.geoplugin.net/json.gp?ip=');
+            $ipdat = @json_decode(file_get_contents($geopluginUrl.$ip));
             if (@strlen(trim($ipdat->geoplugin_countryCode)) == 2) {
                 switch ($purpose) {
                     case 'location':

--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -176,4 +176,8 @@ return [
     // LiveSearch for scalability
     'enableLiveSearch'          => env('LARAVEL_LOGGER_LIVE_SEARCH_ENABLED', true),
 
+    // GeoPlugin for IP lookup
+    'enableGeoPlugin'           => env('LARAVEL_LOGGER_GEO_PLUGIN_ENABLED', true),
+    'geoPluginUrl'              => env('LARAVEL_LOGGER_GEO_PLUGIN_URL', 'http://www.geoplugin.net/json.gp?ip='),
+
 ];


### PR DESCRIPTION
GeoPlugin configuration settings; enable toggle and API URL.

Adds configuration settings to be able to disable the GeoPlugin used from the log activity views.

Disable in `.env` with:

```
LARAVEL_LOGGER_GEO_PLUGIN_ENABLED=false
```

... and you should see a lot more `Additional Ip Address Data Not Available` on individual activity log entries.

(The usual caveats about published config files apply; republish or merge to ensure setting is picked up.)
