### PR TITLE
Update laravel-logger.php

### DIFF
--- a/src/config/laravel-logger.php
+++ b/src/config/laravel-logger.php
@@ -27,7 +27,7 @@ return [
     */
 
     'loggerMiddlewareEnabled'   => env('LARAVEL_LOGGER_MIDDLEWARE_ENABLED', true),
-    'loggerMiddlewareExcept'    => array_filter(explode(',', trim((string) env('LARAVEL_LOGGER_MIDDLEWARE_EXCEPT') ?? ''))),
+    'loggerMiddlewareExcept'    => array_filter(explode(',', trim((string) env('LARAVEL_LOGGER_MIDDLEWARE_EXCEPT', '')))),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
We copied the config to our own `/config` directory and PHPStan reported the following error:

```md
 ------ ----------------------------------------------------- 
  Line   laravel-logger.php                                   
 ------ ----------------------------------------------------- 
  30     Expression on left side of ?? is not nullable.       
         🪪 nullCoalesce.expr                                 
 ------ ----------------------------------------------------- 
```

This happens because the `(string)` cast has a **higher** operator precedence than the `??` null coalescing operator.

I changed the code to use the built-in fallback of the `env()` function instead.